### PR TITLE
let subtest callbacks take args

### DIFF
--- a/picotest.c
+++ b/picotest.c
@@ -77,7 +77,7 @@ int done_testing(void)
     return test_fail[test_level];
 }
 
-void subtest(const char *name, void (*cb)(void))
+void enter_subtest(const char *name)
 {
     ++test_level;
 
@@ -85,9 +85,10 @@ void subtest(const char *name, void (*cb)(void))
     test_fail[test_level] = 0;
 
     note("Subtest: %s", name);
+}
 
-    cb();
-
+void exit_subtest(const char *name)
+{
     done_testing();
 
     --test_level;

--- a/picotest.h
+++ b/picotest.h
@@ -34,11 +34,19 @@ extern "C" {
 
 extern int test_index[32];
 
-void note(const char *fmt, ...)  __attribute__((format (printf, 1, 2)));
-void _ok(int cond, const char *fmt, ...) __attribute__((format (printf, 2, 3)));
+void note(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void _ok(int cond, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 #define ok(cond) _ok(cond, "%s %d", __FILE__, __LINE__)
 int done_testing(void);
-void subtest(const char *name, void (*cb)(void));
+#define subtest(name, cb, ...)                                                                                                     \
+    do {                                                                                                                           \
+        const char *_name = (name);                                                                                                \
+        enter_subtest(_name);                                                                                                      \
+        (cb)(__VA_ARGS__);                                                                                                         \
+        exit_subtest(_name);                                                                                                       \
+    } while (0)
+void enter_subtest(const char *name);
+void exit_subtest(const char *name);
 /**
  * Returns if the test is at the expected position.  For example, `test_is_at(3, 2, 0)` returns true if it is running the 3rd test at
  * the top level, which is a subtest in which the next test to be run is the second one.  The last `0` is the terminator.


### PR DESCRIPTION
With the use of variadic macros, any number of arguments (of any type) can be passed to the subtest; e.g.,:

```c
static void my_subtest(const char *mode)
{
    if (mode ...)
       ...
}
...
    subtest("my-subtest-a", my_subtest, "a");
    subtest("my-subtest-b", my_subtest, "b");
```